### PR TITLE
Make Irbtools.libs= possible

### DIFF
--- a/lib/irbtools/configure.rb
+++ b/lib/irbtools/configure.rb
@@ -49,6 +49,11 @@ else
       end
       aliases_for :libs, :gems, :libraries
 
+      def libs=(value)
+        @libs = value
+      end
+      aliases_for :libs=, :gems=, :libraries=
+
       def init
         require File.expand_path( '../irbtools.rb', File.dirname(__FILE__) )
       end


### PR DESCRIPTION
The README says I can set the libs of my choosing as

```
Irbtools.libs = ...
```

But I cannot seem to do it without defining the writer method. My commit does just that.
