### PR TITLE
two fixes

### DIFF
--- a/lib/irbtools.rb
+++ b/lib/irbtools.rb
@@ -1,103 +1,101 @@
 # encoding: utf-8
 
-# # # # #
-# require 'irbtools' in your .irbrc
-# see the README file for more information
-require File.expand_path('irbtools/configure', File.dirname(__FILE__) ) unless defined? Irbtools
+if defined? ::IRB
+  # # # # #
+  # require 'irbtools' in your .irbrc
+  # see the README file for more information
+  require File.expand_path('irbtools/configure', File.dirname(__FILE__) ) unless defined? Irbtools
 
-# # # # #
-# load extension packages
-Irbtools.packages.each{ |pkg|
-  begin
-    require "irbtools/#{pkg}"
-
-  rescue LoadError => err
-    warn "Couldn't load an extension package: #{err}"
-  end
-}
-
-# # # # #
-# load libraries
-
-# load helper proc
-load_libraries_proc = proc{ |libs|
-  remember_verbose_and_debug = $VERBOSE, $DEBUG
-  $VERBOSE = $DEBUG = false
-
-  libs.each{ |lib|
+  # # # # #
+  # load extension packages
+  Irbtools.packages.each{ |pkg|
     begin
-      require lib.to_s
-
-      Irbtools.send :library_loaded, lib
+      require "irbtools/#{pkg}"
 
     rescue LoadError => err
-      warn "Couldn't load an irb library: #{err}"
+      warn "Couldn't load an extension package: #{err}"
     end
   }
-  $VERBOSE, $DEBUG = remember_verbose_and_debug
-}
 
-# load them :)
-load_libraries_proc[ Irbtools.libraries ]
+  # # # # #
+  # load libraries
 
-# load these each time a new sub irb starts (only if supported)
-if defined? ::IRB
+  # load helper proc
+  load_libraries_proc = proc{ |libs|
+    remember_verbose_and_debug = $VERBOSE, $DEBUG
+    $VERBOSE = $DEBUG = false
+
+    libs.each{ |lib|
+      begin
+        require lib.to_s
+
+        Irbtools.send :library_loaded, lib
+
+      rescue LoadError => err
+        warn "Couldn't load an irb library: #{err}"
+      end
+    }
+    $VERBOSE, $DEBUG = remember_verbose_and_debug
+  }
+
+  # load them :)
+  load_libraries_proc[ Irbtools.libraries ]
+
+  # load these each time a new sub irb starts (only if supported)
   original_irbrc_proc = IRB.conf[:IRB_RC]
   IRB.conf[:IRB_RC] = proc{
     load_libraries_proc[ Irbtools.libraries_in_proc ]
     original_irbrc_proc[ ]  if original_irbrc_proc
   }
-else
-  load_libraries_proc[ Irbtools.libraries_in_proc ]
-end
 
 
-# # # # #
-# general shortcuts & helper methods
-require File.expand_path('irbtools/general', File.dirname(__FILE__) )
+  # # # # #
+  # general shortcuts & helper methods
+  require File.expand_path('irbtools/general', File.dirname(__FILE__) )
 
-# # # # #
-# irb options
-if defined? ::IRB && !defined? ::Ripl
-  IRB.conf[:AUTO_INDENT]  = true                 # simple auto indent
-  IRB.conf[:EVAL_HISTORY] = 42424242424242424242 # creates the special __ variable
-  IRB.conf[:SAVE_HISTORY] = 2000                 # how many lines will go to ~/.irb_history
+  # # # # #
+  # irb options
+  unless defined? ::Ripl
+    IRB.conf[:AUTO_INDENT]  = true                 # simple auto indent
+    IRB.conf[:EVAL_HISTORY] = 42424242424242424242 # creates the special __ variable
+    IRB.conf[:SAVE_HISTORY] = 2000                 # how many lines will go to ~/.irb_history
 
-  # prompt
-  (IRB.conf[:PROMPT] ||= {} ).merge!( {:IRBTOOLS => {
-    :PROMPT_I => ">> ",    # normal
-    :PROMPT_N => "|  ",    # indenting
-    :PROMPT_C => " > ",    # continuing a statement
-    :PROMPT_S => "%l> ",   # continuing a string
-    :RETURN   => "=> %s \n",
-    :AUTO_INDENT => true,
-  }})
+    # prompt
+    (IRB.conf[:PROMPT] ||= {} ).merge!( {:IRBTOOLS => {
+      :PROMPT_I => ">> ",    # normal
+      :PROMPT_N => "|  ",    # indenting
+      :PROMPT_C => " > ",    # continuing a statement
+      :PROMPT_S => "%l> ",   # continuing a string
+      :RETURN   => "=> %s \n",
+      :AUTO_INDENT => true,
+    }})
 
-  IRB.conf[:PROMPT_MODE] = :IRBTOOLS
-end
-
-# # # # #
-# misc
-
-# add current directory to the load path
-$: << '.'  if RubyVersion.is.at_least? '1.9.2'
-
-# shorter ruby info constants
-Object.const_set :RV, RubyVersion  rescue nil
-Object.const_set :RE, RubyEngine   rescue nil
-
-# load rails.rc
-begin
-  if ( ENV['RAILS_ENV'] || defined? Rails ) && Irbtools.railsrc && File.exist?(Irbtools.railsrc)
-    load File.expand_path( Irbtools.railsrc )
+    IRB.conf[:PROMPT_MODE] = :IRBTOOLS
   end
-rescue
-end
 
-# # # # #
-# done :)
-if msg = Irbtools.welcome_message
-  puts msg
+  # # # # #
+  # misc
+
+  # add current directory to the load path
+  $: << '.'  if RubyVersion.is.at_least? '1.9.2'
+
+  # shorter ruby info constants
+  Object.const_set :RV, RubyVersion  rescue nil
+  Object.const_set :RE, RubyEngine   rescue nil
+
+  # load rails.rc
+  begin
+    if ( ENV['RAILS_ENV'] || defined? Rails ) && Irbtools.railsrc && File.exist?(Irbtools.railsrc)
+      load File.expand_path( Irbtools.railsrc )
+    end
+  rescue
+  end
+
+  # # # # #
+  # done :)
+  if msg = Irbtools.welcome_message
+    puts msg
+  end
 end
 
 # J-_-L


### PR DESCRIPTION
- fixed a LoadError when ~/.railsrc does not exist

Added a check for file existence.
- load the whole functionality only when on irb

irbtools throws "uninitialized constant IRB" when loaded outside of irb.
My real world use case was on Rails 3 and Bundler.
When irbtools is bundled, Bundler tries to require it on start up for everything, such as `rails server` or `rails runner` or `rake`. And causes the "uninitialized constant IRB" error.
So, I hope irbtools to do nothing if IRB is not defined.
