### PR TITLE
Fixed Rubinius compatibility problem

### DIFF
--- a/lib/irbtools/libraries.rb
+++ b/lib/irbtools/libraries.rb
@@ -62,7 +62,9 @@ end
 Irbtools.add_library 'every_day_irb', :thread => 10 
 
 # nice debug printing (q, o, c, .m, .d)
-Irbtools.add_library 'zucker/debug', :thread => 20
+unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
+  Irbtools.add_library 'zucker/debug', :thread => 20 
+end
 
 # nice debug printing (ap)
 Irbtools.add_library 'ap', :thread => 30


### PR DESCRIPTION
I added a condition to check for rbx before adding zucker/debug. 
This means that rubinius users can simple put:
`require 'irbtools'`

Or

`require 'irbtools/configure'``

And it will work :). Perviously requiring irbtools would cause a rubinius stack error
