### PR TITLE
bump binding.repl version to ~> v3.0.0

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,7 +27,7 @@ To integrate *irbtools* into a Rails console, you should <tt>irbtools</tt> to yo
 
   gem 'irbtools', require: 'binding.repl'
 
-Thanks to help from the {binding.repl}[https://github.com/robgleeson/binding.repl] gem, you can start IRB (with *irbtools*) directly from your code:
+Thanks to help from the {binding.repl}[https://github.com/rpag/binding.repl] gem, you can start IRB (with *irbtools*) directly from your code:
 
   binding.repl!
 

--- a/irbtools.gemspec
+++ b/irbtools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   # functionality
   s.add_dependency %q<every_day_irb>, ">= #{ s.version }"
-  s.add_dependency %q<binding.repl>,  ">= 1.0.1"
+  s.add_dependency %q<binding.repl>,  "~> 3.0.0"
   s.add_dependency %q<boson>,         "~> 1.2.4"
   s.add_dependency %q<boson-more>,    "~> 0.2.2"
   s.add_dependency %q<alias>,         "~> 0.2.3"

--- a/lib/irbtools/libraries.rb
+++ b/lib/irbtools/libraries.rb
@@ -8,7 +8,7 @@ require 'rbconfig'
 
 Irbtools.add_library :yaml
 Irbtools.add_library 'binding.repl' do
-  Binding.repl.auto_order = %w[irb ripl rib pry]
+  BindingRepl.auto = %w[irb ripl rib pry]
 end
 
 


### PR DESCRIPTION
Hi,
binding.repl v3.0.0 was released today. The pull request updates the gemspec to depend on ~> 3.0.0, and updates irbtools to use `BindingRepl.auto =` instead of `Binding.repl.auto_order =` which was removed and renamed in v3.0.0 because I didn't think it was worth the monkey patch on the Binding class. I also updated the link in the README file since it currently 404s. 

I have prepared a pull request for the 'debugging' gem since its dependency currently conflicts with the dependency that irbtools has in this PR. v3.0.0 of binding.repl removes some poor decisions I made when I started the project, and it also supports the lesser known "ir" repl. I hope you can accept the PR. Let me know if there is any changes you'd like me to make before you can merge it. Thanks!