### PR TITLE
Expand irb version constraint to all 1.x versions

### DIFF
--- a/irbtools.gemspec
+++ b/irbtools.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Dependencies
 
   # Core Functionality
-  s.add_dependency %q<irb>,           "~> 1.12.0"
+  s.add_dependency %q<irb>,           ">= 1.12.0", "< 2.0"
   s.add_dependency %q<every_day_irb>, "~> 2.2"
   s.add_dependency %q<fancy_irb>,     "~> 2.1"
   s.add_dependency %q<wirb>,          "~> 2.0", ">= 2.2.1"


### PR DESCRIPTION
This fixes #57 by allowing any version of irb >= 1.12 that isn't a major version bump. Hopefully that's not too risky.